### PR TITLE
YDA-4334: fix lock dataset function intake

### DIFF
--- a/controllers/Intake.php
+++ b/controllers/Intake.php
@@ -179,7 +179,7 @@ class Intake extends MY_Controller
         $result=0;
         // per collection find latest lock/freeze-status. Possibly the presented data is outdated.
         foreach($datasets as $datasetId){
-            $this->api->call('intake_lock_dataset', ["path" => $this->intake_path, "dataset_id" => $datasetId]);
+            $this->api->call('intake_lock_dataset', ["path" => $this->intake_path, "dataset_ids" => $datasetId]);
         }
 
         $this->output->set_output(json_encode(array(


### PR DESCRIPTION
The function for locking datasets wasn't working because of
a parameter name mismatch between the intake module and
the ruleset.

If PR is accepted, please also merge into release-1.7 branch